### PR TITLE
Add support for Framework Version and some tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -190,3 +190,4 @@ docs/content/license.md
 docs/content/release-notes.md
 .fake
 docs/tools/FSharp.Formatting.svclog
+TestResult.xml

--- a/build.fsx
+++ b/build.fsx
@@ -8,6 +8,7 @@ open Fake.Git
 open Fake.AssemblyInfoFile
 open Fake.ReleaseNotesHelper
 open Fake.UserInputHelper
+open Fake.Testing
 open System
 open System.IO
 #if MONO
@@ -145,11 +146,11 @@ Target "Build" (fun _ ->
 
 Target "RunTests" (fun _ ->
     !! testAssemblies
-    |> NUnit (fun p ->
+    |> NUnit3  (fun p ->
         { p with
-            DisableShadowCopy = true
+            ShadowCopy = true
             TimeOut = TimeSpan.FromMinutes 20.
-            OutputFile = "TestResults.xml" })
+            OutputDir  = "TestResults.xml" })
 )
 
 #if MONO
@@ -406,5 +407,5 @@ Target "All" DoNothing
 
 "ReleaseDocs"
   ==> "Release"
-  
+
 RunTargetOrDefault "All"

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -21,3 +21,4 @@ group Test
 
   nuget NUnit
   nuget NUnit.Runners
+  nuget FsUnit

--- a/paket.lock
+++ b/paket.lock
@@ -37,6 +37,10 @@ GITHUB
 GROUP Test
 NUGET
   remote: https://www.nuget.org/api/v2
+    FSharp.Core (4.0.0.1)
+    FsUnit (2.3.1)
+      FSharp.Core (>= 3.1.2.5)
+      NUnit (3.4.1)
     NUnit (3.4.1)
     NUnit.ConsoleRunner (3.4.1)
     NUnit.Extension.NUnitProjectLoader (3.4.1)

--- a/src/fstoml/Conditions.fs
+++ b/src/fstoml/Conditions.fs
@@ -60,18 +60,18 @@ let tryParseTarget = function
     | _ ->  None
 
 let tryParseVersion = function
-    | InvariantEqual "1.0" -> Some FrameworkVersion.V1_0
-    | InvariantEqual "1.1" -> Some FrameworkVersion.V1_1
-    | InvariantEqual "1.2" -> Some FrameworkVersion.V1_2
-    | InvariantEqual "1.3" -> Some FrameworkVersion.V1_3
-    | InvariantEqual "1.4" -> Some FrameworkVersion.V1_4
-    | InvariantEqual "1.5" -> Some FrameworkVersion.V1_5
-    | InvariantEqual "1.6" -> Some FrameworkVersion.V1_6
-    | InvariantEqual "4.5" -> Some FrameworkVersion.V4_5
-    | InvariantEqual "4.5.1" -> Some FrameworkVersion.V4_5_1
-    | InvariantEqual "4.6" -> Some FrameworkVersion.V4_6
-    | InvariantEqual "4.6.1" -> Some FrameworkVersion.V4_6_1
-    | InvariantEqual "4.6.2" -> Some FrameworkVersion.V4_6_2
+    | InvariantEqual "1_0" -> Some FrameworkVersion.V1_0
+    | InvariantEqual "1_1" -> Some FrameworkVersion.V1_1
+    | InvariantEqual "1_2" -> Some FrameworkVersion.V1_2
+    | InvariantEqual "1_3" -> Some FrameworkVersion.V1_3
+    | InvariantEqual "1_4" -> Some FrameworkVersion.V1_4
+    | InvariantEqual "1_5" -> Some FrameworkVersion.V1_5
+    | InvariantEqual "1_6" -> Some FrameworkVersion.V1_6
+    | InvariantEqual "4_5" -> Some FrameworkVersion.V4_5
+    | InvariantEqual "4_5_1" -> Some FrameworkVersion.V4_5_1
+    | InvariantEqual "4_6" -> Some FrameworkVersion.V4_6
+    | InvariantEqual "4_6_1" -> Some FrameworkVersion.V4_6_1
+    | InvariantEqual "4_6_2" -> Some FrameworkVersion.V4_6_2
     | _ -> None
 
 let tryParsePlatform = function

--- a/src/fstoml/Script.fsx
+++ b/src/fstoml/Script.fsx
@@ -14,7 +14,7 @@ f
 
 //OUTPUT:
 
-// "<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+// <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 // <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 //   <PropertyGroup>
 //     <Name>Library1</Name>
@@ -23,7 +23,7 @@ f
 //     <SchemaVersion>2.0</SchemaVersion>
 //     <ProjectGuid>bb0c6f01-5e57-4575-a498-5de850d9fa6c</ProjectGuid>
 //     <OutputType>Library</OutputType>
-//     <TargetFSharpCoreVersion>FsToml.ProjectSystem+FSharpVer</TargetFSharpCoreVersion>
+//     <TargetFSharpCoreVersion>4.4.0.0</TargetFSharpCoreVersion>
 //   </PropertyGroup>
 //   <PropertyGroup Condition="">
 //     <DebugSymbols>true</DebugSymbols>
@@ -34,15 +34,15 @@ f
 //   <PropertyGroup Condition="('$(TargetFrameworkIdentifier)' == '.NETCoreApp')">
 //     <DebugSymbols>false</DebugSymbols>
 //   </PropertyGroup>
-//   <PropertyGroup Condition="('$(TargetFrameworkIdentifier)' == '.NETCoreApp') AND ('$(Configuration)' =='Release')">
+//   <PropertyGroup Condition="('$(TargetFrameworkIdentifier)' == '.NETCoreApp') AND ('$(Configuration)' == 'Release')">
 //     <DebugType>PdbOnly</DebugType>
 //     <Optimize>true</Optimize>
 //     <DefineConstants>RELEASE;FABLE</DefineConstants>
 //   </PropertyGroup>
-//   <PropertyGroup Condition="('$(TargetFrameworkIdentifier)' == '.NETCoreApp') AND ('$(Platform)' == 'x86') AND ('$(Configuration)' =='Release')">
+//   <PropertyGroup Condition="('$(TargetFrameworkIdentifier)' == '.NETCoreApp') AND ('$(TargetFrameworkVersion)' == 'v1.6') AND ('$(Platform)' == 'x86') AND ('$(Configuration)' == 'Release')">
 //     <OutputPath>bin/Release/x86</OutputPath>
 //   </PropertyGroup>
-//   <PropertyGroup Condition="('$(TargetFrameworkIdentifier)' == '.NETCoreApp') AND ('$(Platform)' == 'x64') AND ('$(Configuration)' =='Release')">
+//   <PropertyGroup Condition="('$(TargetFrameworkIdentifier)' == '.NETCoreApp') AND ('$(TargetFrameworkVersion)' == 'v1.6') AND ('$(Platform)' == 'x64') AND ('$(Configuration)' == 'Release')">
 //     <OutputPath>bin/Release/x64</OutputPath>
 //   </PropertyGroup>
 //   <ItemGroup>
@@ -68,4 +68,4 @@ f
 //     <Compile Include="src/file3.fs" />
 //     <None Include="src/script.fsx" />
 //   </ItemGroup>
-// </Project>"
+// </Project>

--- a/src/fstoml/testproject.toml
+++ b/src/fstoml/testproject.toml
@@ -42,10 +42,10 @@ OtherFlags = [ '--warnon:1182' ]
     DebugType = 'pdbonly'
     Optimize = true
 
-[ netcore."1.6".Release.x86 ]
+[ netcore."1_6".Release.x86 ]
     OutputPath = "bin/Release/x86"
 
-[ netcore."1.6".Release.x64 ]
+[ netcore."1_6".Release.x64 ]
     OutputPath = "bin/Release/x64"
 
 

--- a/tests/fstoml.Tests/ConditionsTests.fs
+++ b/tests/fstoml.Tests/ConditionsTests.fs
@@ -1,7 +1,8 @@
-module fstoml.Tests
+module FsToml.Tests.Conditions
 
 open FsToml
 open NUnit.Framework
+
 
 [<Test>]
 let ``hello returns 42`` () =

--- a/tests/fstoml.Tests/ConditionsTests.fs
+++ b/tests/fstoml.Tests/ConditionsTests.fs
@@ -1,9 +1,120 @@
 module FsToml.Tests.Conditions
 
-open FsToml
 open NUnit.Framework
+open FsUnit
+
+open FsToml
+open Conditions
+open ProjectSystem
 
 
 [<Test>]
-let ``hello returns 42`` () =
-  Assert.AreEqual(42,42)
+let ``Parse `netcore.1_6.Release.x86` `` () =
+    """netcore.1_6.Release.x86"""
+    |> parseTomlCondition
+    |> should equal {
+        FrameworkTarget = Some FrameworkTarget.NetcoreApp
+        FrameworkVersion = Some FrameworkVersion.V1_6
+        BuildType = Some BuildType.Release
+        PlatformType = Some PlatformType.X86
+      }
+
+[<Test>]
+let ``Parse `netcore.1_6.Release.x64` `` () =
+    """netcore.1_6.Release.x64"""
+    |> parseTomlCondition
+    |> should equal {
+        FrameworkTarget = Some FrameworkTarget.NetcoreApp
+        FrameworkVersion = Some FrameworkVersion.V1_6
+        BuildType = Some BuildType.Release
+        PlatformType = Some PlatformType.X64
+      }
+
+[<Test>]
+let ``Parse `netcore.1_6.Release.AnyCPU` `` () =
+    """netcore.1_6.Release.AnyCPU"""
+    |> parseTomlCondition
+    |> should equal {
+        FrameworkTarget = Some FrameworkTarget.NetcoreApp
+        FrameworkVersion = Some FrameworkVersion.V1_6
+        BuildType = Some BuildType.Release
+        PlatformType = Some PlatformType.AnyCPU
+      }
+
+[<Test>]
+let ``Parse `netcore.1_6.Release.Blah` `` () =
+    """netcore.1_6.Release.Blah"""
+    |> parseTomlCondition
+    |> should equal {
+        FrameworkTarget = Some FrameworkTarget.NetcoreApp
+        FrameworkVersion = Some FrameworkVersion.V1_6
+        BuildType = Some BuildType.Release
+        PlatformType = None
+      }
+
+[<Test>]
+let ``Parse `netcore.1_6.Release` `` () =
+    """netcore.1_6.Release"""
+    |> parseTomlCondition
+    |> should equal {
+        FrameworkTarget = Some FrameworkTarget.NetcoreApp
+        FrameworkVersion = Some FrameworkVersion.V1_6
+        BuildType = Some BuildType.Release
+        PlatformType = None
+      }
+
+
+[<Test>]
+let ``Parse `netcore.1_6.Debug.x86` `` () =
+    """netcore.1_6.Debug.x86"""
+    |> parseTomlCondition
+    |> should equal {
+        FrameworkTarget = Some FrameworkTarget.NetcoreApp
+        FrameworkVersion = Some FrameworkVersion.V1_6
+        BuildType = Some BuildType.Debug
+        PlatformType = Some PlatformType.X86
+      }
+
+[<Test>]
+let ``Parse `netcore.1_6.Blah.x86` `` () =
+    """netcore.1_6.Blah.x86"""
+    |> parseTomlCondition
+    |> should equal {
+        FrameworkTarget = Some FrameworkTarget.NetcoreApp
+        FrameworkVersion = Some FrameworkVersion.V1_6
+        BuildType = None
+        PlatformType = Some PlatformType.X86
+      }
+
+[<Test>]
+let ``Parse `netcore.1_6.x86` `` () =
+    """netcore.1_6.x86"""
+    |> parseTomlCondition
+    |> should equal {
+        FrameworkTarget = Some FrameworkTarget.NetcoreApp
+        FrameworkVersion = Some FrameworkVersion.V1_6
+        BuildType = None
+        PlatformType = Some PlatformType.X86
+      }
+
+[<Test>]
+let ``Parse `net.4_6.Release.x86` `` () =
+    """net.4_6.Release.x86"""
+    |> parseTomlCondition
+    |> should equal {
+        FrameworkTarget = Some FrameworkTarget.Net
+        FrameworkVersion = Some FrameworkVersion.V4_6
+        BuildType = Some BuildType.Release
+        PlatformType = Some PlatformType.X86
+      }
+
+[<Test>]
+let ``Parse `netstandard.1_0.Release.x86` `` () =
+    """netstandard.1_0.Release.x86"""
+    |> parseTomlCondition
+    |> should equal {
+        FrameworkTarget = Some FrameworkTarget.NetStandard
+        FrameworkVersion = Some FrameworkVersion.V1_0
+        BuildType = Some BuildType.Release
+        PlatformType = Some PlatformType.X86
+      }

--- a/tests/fstoml.Tests/fstoml.Tests.fsproj
+++ b/tests/fstoml.Tests/fstoml.Tests.fsproj
@@ -1,68 +1,34 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
+    <Name>FsToml.Tests</Name>
+    <AssemblyName>FsToml.Tests</AssemblyName>
+    <RootNamespace>FsToml.Tests</RootNamespace>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>b8b3f011-54f3-43d3-bc94-3ecbe5a3770c</ProjectGuid>
     <OutputType>Library</OutputType>
-    <RootNamespace>FsToml.Tests</RootNamespace>
-    <AssemblyName>FsToml.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <TargetFSharpCoreVersion>4.4.0.0</TargetFSharpCoreVersion>
-    <Name>FsToml.Tests</Name>
-    <TargetFrameworkProfile />
-    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
+    <DebugType>Full</DebugType>
     <Optimize>false</Optimize>
     <Tailcalls>false</Tailcalls>
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
-    <StartAction>Project</StartAction>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>PdbOnly</DebugType>
     <Optimize>true</Optimize>
     <Tailcalls>true</Tailcalls>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
   </PropertyGroup>
-  <PropertyGroup>
-    <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
-  </PropertyGroup>
-  <Choose>
-    <When Condition="'$(VisualStudioVersion)' == '11.0'">
-      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')">
-        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
-      </PropertyGroup>
-    </When>
-    <Otherwise>
-      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
-        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
-      </PropertyGroup>
-    </Otherwise>
-  </Choose>
-  <Import Project="$(FSharpTargetsPath)" />
-  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
-  <Import Project="..\..\.paket\paket.targets" />
-  <ItemGroup>
-    <Compile Include="Tests.fs" />
-    <None Include="paket.references" />
-    <Content Include="App.config" />
-  </ItemGroup>
   <ItemGroup>
     <Reference Include="FSharp.Core, Version=4.4.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Private>True</Private>
@@ -79,6 +45,43 @@
       <Private>True</Private>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="paket.references" />
+    <Content Include="App.config" />
+    <Compile Include="ConditionsTests.fs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '11.0'">
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(FSharpTargetsPath)" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Import Project="..\..\.paket\paket.targets" />
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
+      <ItemGroup>
+        <Reference Include="FsUnit.NUnit">
+          <HintPath>..\..\packages\test\FsUnit\lib\net45\FsUnit.NUnit.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="NHamcrest">
+          <HintPath>..\..\packages\test\FsUnit\lib\net45\NHamcrest.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
   <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v2.0' Or $(TargetFrameworkVersion) == 'v3.0')">
       <ItemGroup>

--- a/tests/fstoml.Tests/paket.references
+++ b/tests/fstoml.Tests/paket.references
@@ -2,3 +2,4 @@ FSharp.Core
 group Test
 NUnit
 NUnit.Runners
+FsUnit


### PR DESCRIPTION
It's not compatiable with proposed in #4 schema [using `[ netcore."1_6".Release.x64 ]` instead of `[ netcore."1.6".Release.x64 ]` ] but it's just easier to parse without any real disadvantage, IMO.

Also added some tests for function responsible for parsing build targets.
