### PR TITLE
Change References format

### DIFF
--- a/sample/Deppy.fsproj
+++ b/sample/Deppy.fsproj
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Name>FsToml</Name>
+    <AssemblyName>FsToml</AssemblyName>
+    <RootNamespace>FsToml</RootNamespace>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>8a5d713d-7ada-4c22-ab94-6ba8345a644b</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFSharpCoreVersion>4.4.0.0</TargetFSharpCoreVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>Full</DebugType>
+    <Optimize>false</Optimize>
+    <Tailcalls>false</Tailcalls>
+    <OutputPath>.\bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <OtherFlags>--warnon:1182</OtherFlags>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>PdbOnly</DebugType>
+    <Optimize>true</Optimize>
+    <Tailcalls>true</Tailcalls>
+    <OutputPath>.\bin\Release</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <OtherFlags>--warnon:1182</OtherFlags>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
+  </ItemGroup>
+  <ItemGroup>
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '11.0'">
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(FSharpTargetsPath)" Condition="Exists('$(FSharpTargetsPath)')" />
+</Project>

--- a/sample/Sample.fsproj.fsx
+++ b/sample/Sample.fsproj.fsx
@@ -49,15 +49,14 @@ f
 //   <ItemGroup>
 //     <Reference Include="System" />
 //     <Reference Include="FSharp.Core" />
-//     <Reference Include="Fable.Core">
+//     <Reference Include="lib/Fable.Core.dll">
 //       <Private>False</Private>
 //     </Reference>
 //   </ItemGroup>
 //   <ItemGroup>
-//     <ProjectReference Include="">
-//       <Name>Deppy</Name>
-//       <Project>{f3d0b372-3af7-49d9-98ed-5a78e9416098}</Project>
-//       <Private>False</Private>
+//     <ProjectReference Include="Deppy.fsproj">
+//       <Name>Deppy.fsproj</Name>
+//       <Project>{8a5d713d-7ada-4c22-ab94-6ba8345a644b}</Project>
 //     </ProjectReference>
 //   </ItemGroup>
 //   <ItemGroup>
@@ -69,4 +68,4 @@ f
 //     <Compile Include="src/file3.fs" />
 //     <None Include="src/script.fsx" />
 //   </ItemGroup>
-// </Project>"
+// </Project>

--- a/sample/testproject.CompilerService.toml
+++ b/sample/testproject.CompilerService.toml
@@ -22,7 +22,7 @@ References = [
     { Framework = "System.Xml.Linq" },
     { Library = "..\\packages\\FSharp.Compiler.Service\\lib\\net45\\FSharp.Compiler.Service.dll", Private=true},
     { Library = "..\\packages\\System.Collections.Immutable\\lib\\netstandard1.0\\System.Collections.Immutable.dll", Private=true},
-    { Library = "..\\packages\\System.Reflection.Metadata\\lib\\netstandard1.1\\System.Reflection.Metadata.dll", Private=true}
+    { Library = "..\\packages\\System.Reflection.Metadata\\lib\\netstandard1.1\\System.Reflection.Metadata.dll", Private=true},
     { Project = "..\src\FsToml\FsToml.fsproj" }
 ]
 

--- a/sample/testproject.CompilerService.toml
+++ b/sample/testproject.CompilerService.toml
@@ -15,18 +15,15 @@ Files = [
 ]
 
 References = [
-    { Include = "System" },
-    { Include = "System.Core" },
-    { Include = "System.Numerics" },
-    { Include = "System.Xml" },
-    { Include = "System.Xml.Linq" },
-    { Include = "..\\packages\\FSharp.Compiler.Service\\lib\\net45\\FSharp.Compiler.Service.dll", Private=true},
-    { Include = "..\\packages\\System.Collections.Immutable\\lib\\netstandard1.0\\System.Collections.Immutable.dll", Private=true},
-    { Include = "..\\packages\\System.Reflection.Metadata\\lib\\netstandard1.1\\System.Reflection.Metadata.dll", Private=true}
-]
-
-ProjectReferences = [
-    { Name = 'FsToml.fsproj', Include = '..\src\FsToml\FsToml.fsproj',  Project = "8a5d713d-7ada-4c22-ab94-6ba8345a644b" },
+    { Framework = "System" },
+    { Framework = "System.Core" },
+    { Framework = "System.Numerics" },
+    { Framework = "System.Xml" },
+    { Framework = "System.Xml.Linq" },
+    { Library = "..\\packages\\FSharp.Compiler.Service\\lib\\net45\\FSharp.Compiler.Service.dll", Private=true},
+    { Library = "..\\packages\\System.Collections.Immutable\\lib\\netstandard1.0\\System.Collections.Immutable.dll", Private=true},
+    { Library = "..\\packages\\System.Reflection.Metadata\\lib\\netstandard1.1\\System.Reflection.Metadata.dll", Private=true}
+    { Project = "..\src\FsToml\FsToml.fsproj" }
 ]
 
 # configurations

--- a/sample/testproject.toml
+++ b/sample/testproject.toml
@@ -17,15 +17,12 @@ Files = [
 ]
 
 References = [
-    { Include = "System" },
-    { Include = "FSharp.Core", CopyLocal = 'Always' },
-    { Include = "Fable.Core", Private = true },
+    { Framework = "System" },
+    { Framework = "FSharp.Core", CopyLocal = 'Always' },
+    { Project   = "Deppy.fsproj" },
+    { Project   = "Deppy2.toml" },
+    { Library   = "lib/Fable.Core.dll", Private = true }
 ]
-
-ProjectReferences = [
-   { Name = 'Deppy', Project = "f3d0b372-3af7-49d9-98ed-5a78e9416098", Private = true },
-]
-
 
 DebugSymbols = true
 DebugType = 'full'


### PR DESCRIPTION
Unified project references and references:

```
References = [
    { Framework = "System" },
    { Framework = "System.Core" },
    { Framework = "System.Numerics" },
    { Framework = "System.Xml" },
    { Framework = "System.Xml.Linq" },
    { Library = "..\\packages\\FSharp.Compiler.Service\\lib\\net45\\FSharp.Compiler.Service.dll", Private=true},
    { Library = "..\\packages\\System.Collections.Immutable\\lib\\netstandard1.0\\System.Collections.Immutable.dll", Private=true},
    { Library = "..\\packages\\System.Reflection.Metadata\\lib\\netstandard1.1\\System.Reflection.Metadata.dll", Private=true},
    { Project = "..\src\FsToml\FsToml.fsproj" }
]
```

`Guid` for project is no longer necessary - it's read from project file (either `fsproj` or `toml)`. 

Still don't know what to do with references to `.fstoml` projects - right now they are ignored when transforming to `fsrpoj`
